### PR TITLE
Strava Webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This will start with a basic strava integration and (hopefully) grow overtime to
 
 The ultimate goal is to allow users to entirely disconnect their data from external servers if they so desire.
 
+As a warning, everything should be considered unstable until v1.0.0 is released.
+
 ## Strava
 
 The first step in the project is to get some basic data connections to allow users to import their data.

--- a/strava/README.md
+++ b/strava/README.md
@@ -3,107 +3,66 @@
 The strava package provides a CLI tool for interacting with the strava API.
 Further, the package exposes methods that allow you to develop your own ways to interact with the strava API.
 If you like, you can also work directly with the swagger API call methods for less abstraction.
+Finally, strava webhooks are also supported.
 
 ## CLI
+
 The CLI is a relatively easy way to get off the ground and test various things.
-```
-cassidy-strava is a cli tool to interact with the Strava API
-
-Usage:
-  cassidy-strava [flags]
-  cassidy-strava [command]
-
-Available Commands:
-  api            all subcommands here require a token for authentication
-  approval-url   Generate the approval url for the user to grant access.
-  completion     Generate the autocompletion script for the specified shell
-  help           Help about any command
-  initial-access For getting the user's access token for the first time.
-  open-grant     Open a browser to grant allow for permission granting
-
-Flags:
-      --client-id string       the client id of your strava application
-      --client-secret string   the client secret of your strava application
-      --config string          the config file of the application. see config.tmpl.json for format. a config is NOT required if you want to pass everything manually. (default is $HOME/.cassidy-connector-strava.json)
-  -h, --help                   help for cassidy-strava
-  -f, --path string            the path to save successful output to. (will not write errors at this time)
-      --redirect-url string    the redirect url of your strava application (default "http://localhost/exchange_token")
-      --scopes strings         the scope requirement of your strava application (default [activity:read_all])
-  -v, --version                version for cassidy-strava
-
-Use "cassidy-strava [command] --help" for more information about a command.
-```
 
 By default, the CLI will check for a config in `$HOME/.cassidy-connector-strava.json`. You can override this location with the `--config` flag.
 The config is a JSON file structured as follows:
+
 ```
 {
     "client_id": "",
     "client_secret": "",
     "redirect_url": "",
-    "scopes": [],
-    "token_path": ""
+    "scopes": [""],
+    "token_path": "",
+    "authorization_callback_domain": "",
+    "webhook_server_url": ""
 }
 ```
+
 As you can see, there are corresponding flags in the CLI for each of these. The config merely allows the flags to be set when the CLI is run without having to manually enter them each time.
 
 ### CLI API
-The CLI API command exposes all the commands relevant for interacting with strava data.
-```
-all subcommands here require a token for authentication
 
-Usage:
-  cassidy-strava api [flags]
-  cassidy-strava api [command]
-
-Available Commands:
-  activities  Get activities.
-  activity    Get an activity by activity id. Expects an activity id.
-  athlete     Get an authenticated athlete.
-  streams     Get streams for a given activity
-
-Flags:
-  -h, --help                      help for api
-      --token                     a json token. you must include the entire token wrapped in . the json token conforms to `oauth2.Token` struct found here: https://pkg.go.dev/golang.org/x/oauth2#Token. (this is an ugly, but can be useful for testing purposes)
-      --token-path oauth2.Token   the path to a .json file that contains an OAuth2 token. This json must conform to the oauth2.Token struct found here: https://pkg.go.dev/golang.org/x/oauth2#Token.
-
-Global Flags:
-      --client-id string       the client id of your strava application
-      --client-secret string   the client secret of your strava application
-      --config string          the config file of the application. see config.tmpl.json for format. a config is NOT required if you want to pass everything manually. (default is $HOME/.cassidy-connector-strava.json)
-  -f, --path string            the path to save successful output to. (will not write errors at this time)
-      --redirect-url string    the redirect url of your strava application (default "http://localhost/exchange_token")
-      --scopes strings         the scope requirement of your strava application (default [activity:read_all])
-
-Use "cassidy-strava api [command] --help" for more information about a command.
-```
+The CLI `api` command exposes all the commands relevant for interacting with strava data.
 
 Importantly, you must obtain an OAuth2 token to have access to the data. As previously mentioned, this token can either be passed into the CLI directly, or can be stored in a file and loaded through the `--token-path` flag, or via config file specification.
 
 ## Interacting with the Strava API programmatically
+
 All the interaction is governed via the `strava/app` package.
 Create an app in the following way.
+
 ```
 import (
 	"github.com/jcocozza/cassidy-connector/strava/app"
 )
 stravaApp := app.NewApp("client-id", "client-secret", "http://localhost:9999/strava/callback", []string{"activity:read_all"})
 ```
+
 ### Authorizing your Strava Application
+
 Unfortunately, this process is quite involved and takes a great deal of work to set up properly.
 You will need to set up an account and create an API application.
 The process is detailed in the [strava developer docs](https://developers.strava.com/docs/getting-started/).
 
 The app struct directly exposes several methods for facilitating the authentication process for you app..
+
 ```
 stravaApp.OpenAuthorizationGrant() // this opens the approval url in the user's browser
 stravaApp.StartStravaHttpListener() // Listen to the redirect route. Once the user is directed to it, we can extract the token from the url.
 stravaApp.AwaitInitialToken() // Start the listener, push the code to the AuthorizationReciever and get the access token from the authorization code.
 ```
+
 Importantly, the app struct also exposes the `AuthorizationReciever`. This is a string channel (`stravaApp.AuthorizationReciever`).
 If the HttpListener is running, then when the user is redirected to the redirect URL of the strava app (e.g. localhost:9999/strava/exchange) the handler of that route will detect the code from the args of the route and push the code to the channel.
 
 For lower level control over the authentication process, don't use the `AwaitInitialToken()`. Instead, you can leverage some other methods.
+
 ```
 	server, err := s.App.StartStravaHttpListener()
 	if err != nil {
@@ -122,28 +81,34 @@ For lower level control over the authentication process, don't use the `AwaitIni
 Make sure that the server is shutdown before starting a new one otherwise attempting to listen on the same route will throw an error.
 
 ### Swagger (lower level)
+
 The swagger client can be accessed from the app struct via the `StravaClient`.
 The methods are described by the routes at the [strava swagger playground](https://developers.strava.com/playground/).
 For example:
+
 ```
 stravaApp.StravaClient.ActivitiesApi.CreateActivity()
 stravaApp.StravaClient.AthletesApi.UpdateLoggedInAthlete()
 ```
 
 ### Cassidy Wrapper
+
 Our implementation provides wrapper methods that allow you to easily interact with the Strava API with little hassle.
 These are exposed in the app struct via the `Api`.
 For example:
+
 ```
 stravaApp.Api.GetAthlete()
 stravaApp.Api.GetActivity()
 ```
 
 ## IMPORTANT NOTICE
+
 You may need to change the `LatLng` struct in the `strava/internal/swagger/model_lat_lng.go` file to be a list of `float32` (or `float64`). It appears that the `strava/internal/swagger/make.sh` using `swagger-codegen` generates this improperly.
 `type LatLng struct {}` is **INCORRECT**.
 
 The file should look like THIS:
+
 ```
 /*
  * Strava API v3
@@ -160,3 +125,21 @@ package swagger
 type LatLng []float32
 
 ```
+
+## Strava Webhooks
+Read the [strava webhooks docs](https://developers.strava.com/docs/webhooks/) for more info.
+
+At some point you way wish to use webhooks. There is a (relatively) easy way to do this.
+
+When creating an app, specifiy the following params:
+1. authorization callback domain
+  - This is a domain that is exposed to the internet. Strava will send events here via post request. It is also used to create a subscription.
+2. webhook server url
+  - This is where your webserver will running (e.g. `localhost:8080`). All traffic from the authorization callback domain should be routed to here.
+3. webhook verify token (optional) 
+  - (can be just a random string to verity that the data coming from the webhook is yours, but it should remain the same for the entirety of the subscription to the webhook)
+4. webhook event handler (optional, highly recommended)
+  - It is YOUR application's responsibility to process events
+  - this function will be called whenever an event is received by the webserver
+  - strava requires a response within 2 seconds from any webhook request, so the event handler method is called asynchronously with a `go func`.
+  - see the `StravaEvent` struct in `app.go` to understand what events look like.

--- a/strava/app/app.go
+++ b/strava/app/app.go
@@ -73,6 +73,8 @@ type App struct {
 	//
 	// Traffic from AuthorizationCallbackDomain should be routed to this server
 	WebhookServerURL   string
+	// Token to verify that data coming from the webhook is what you expect it to be
+	// Can just be a random string
 	WebhookVerifyToken string
 	Scopes             []string
 	// OAuthConfig handles OAuth and creates the HTTPClient that is used to make requests for the StravaClient
@@ -112,8 +114,8 @@ func generateApprovalUrl(clientId string, redirectUrl string, scopes []string) s
 	return fmt.Sprintf(approvalUrlFormat, clientId, responseType, redirectUrl, approvalPrompt, scopeStr)
 }
 
-// note that webhookRedirectURL and webhookVerifyToken can be empty strings if you aren't interested in webhooks
-func NewApp(clientId string, clientSecret, redirectURL string, authorizationCallbackDomain string, webhookServerURL string, webhookVerifyToken string, scopes []string) *App {
+// note that authorizationCallbackDomain, webhookServerURL, and webhookVerifyToken can be empty strings if you aren't interested in webhooks
+func NewApp(clientId string, clientSecret, redirectURL string, authorizationCallbackDomain string, webhookServerURL string, webhookVerifyToken string, webhookEventHandler func(StravaEvent), scopes []string) *App {
 	approvalUrl := generateApprovalUrl(clientId, redirectURL, scopes)
 	oauthCfg := &oauth2.Config{
 		ClientID:     clientId,
@@ -137,6 +139,7 @@ func NewApp(clientId string, clientSecret, redirectURL string, authorizationCall
 		WebhookServerURL:            webhookServerURL,
 		WebhookVerifyToken:          webhookVerifyToken,
 		WebhookReciever:             webhookReciever,
+		WebhookEventHandler: 		 webhookEventHandler,
 		Scopes:                      scopes,
 		SwaggerConfig:               cfg,
 		OAuthConfig:                 oauthCfg,

--- a/strava/app/app.go
+++ b/strava/app/app.go
@@ -1,13 +1,16 @@
 package app
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/jcocozza/cassidy-connector/strava/app/api"
@@ -18,12 +21,30 @@ import (
 )
 
 const (
-	responseType      string = "code"
-	approvalPrompt    string = "force"
-	approvalUrlFormat        string = "https://www.strava.com/oauth/authorize?client_id=%s&response_type=%s&redirect_uri=%s&approval_prompt=%s&scope=%s"
-    //windowsApprovalUrlFormat string = "https://www.strava.com/oauth/authorize?client_id=%s^&response_type=%s^&redirect_uri=%s^&approval_prompt=%s^&scope=%s"
-	stravaAppSettings string = "https://www.strava.com/settings/apps"
+	responseType            string = "code"
+	approvalPrompt          string = "force"
+	approvalUrlFormat       string = "https://www.strava.com/oauth/authorize?client_id=%s&response_type=%s&redirect_uri=%s&approval_prompt=%s&scope=%s"
+	stravaAppSettings       string = "https://www.strava.com/settings/apps"
+	webhookSubscriptionsURL string = "https://www.strava.com/api/v3/push_subscriptions"
 )
+
+// A StravaEvent is an event that is sent from the webhook
+type StravaEvent struct {
+	// either "activity" or "athlete"
+	ObjectType string `json:"object_type"`
+	// activity id or athlete id based on ObjectType
+	ObjectID int `json:"object_id"`
+	// either "create", "update" or "delete"
+	AspectType string `json:"aspect_type"`
+	// only for AspectType = "update"
+	Updates string `json:"updates"`
+	// athlete's id
+	OwnerID int `json:"owner_id"`
+	// push subscription id receiving the event
+	SubscriptionID int `json:"subscription_id"`
+	// time that the event occured
+	EventTime int `json:"event_time"`
+}
 
 // An app is a way of interacting with the strava api.
 //
@@ -42,7 +63,18 @@ type App struct {
 	ClientId     string
 	ClientSecret string
 	RedirectURL  string
-	Scopes       []string
+	// note that this must be a publicly accessible url otherwise Strava cannot make the challenge request to it
+	//
+	// this must also be set in your strava application
+	// see strava.com/settings/api then press edit.
+	// this should be the "Authorization Callback Domain"
+	AuthorizationCallbackDomain string
+	// where you want the webserver to run for the webhooks e.g. http://localhost:8086
+	//
+	// Traffic from AuthorizationCallbackDomain should be routed to this server
+	WebhookServerURL   string
+	WebhookVerifyToken string
+	Scopes             []string
 	// OAuthConfig handles OAuth and creates the HTTPClient that is used to make requests for the StravaClient
 	OAuthConfig *oauth2.Config
 	// The SwaggerConfig is passed into the creation of the StravaClient.
@@ -61,17 +93,27 @@ type App struct {
 	// A way to get the authorization token from the intial authorization process
 	// Any calls to the stravaRedirectHandler will push the authorization code to the AuthorizationReciver channel.
 	AuthorizationReciever chan string
+	// this ensures that the webhook GET request from strava completes before we move forward
+	WebhookReciever chan string
+	// optional; a user defined function that tells the api how to handle new events
+	//
+	// *IMPORTANT* this will be called asynchronously with a go func
+	// the strava webhook wants a response in less then 2 seconds so all events need to be handled asynchronously
+	WebhookEventHandler func(StravaEvent)
 	// This is where the data methods are called from.
 	// It is a layer of abstraction to simplify making calls to the strava API.
 	// This is the primary purpose of this package.
 	Api *api.StravaAPI
 }
+
 // Format the ApprovalUrlFormat
 func generateApprovalUrl(clientId string, redirectUrl string, scopes []string) string {
 	scopeStr := strings.Join(scopes, ",")
 	return fmt.Sprintf(approvalUrlFormat, clientId, responseType, redirectUrl, approvalPrompt, scopeStr)
 }
-func NewApp(clientId string, clientSecret, redirectURL string, scopes []string) *App {
+
+// note that webhookRedirectURL and webhookVerifyToken can be empty strings if you aren't interested in webhooks
+func NewApp(clientId string, clientSecret, redirectURL string, authorizationCallbackDomain string, webhookServerURL string, webhookVerifyToken string, scopes []string) *App {
 	approvalUrl := generateApprovalUrl(clientId, redirectURL, scopes)
 	oauthCfg := &oauth2.Config{
 		ClientID:     clientId,
@@ -86,11 +128,16 @@ func NewApp(clientId string, clientSecret, redirectURL string, scopes []string) 
 	cfg := swagger.NewConfiguration()
 	client := swagger.NewAPIClient(cfg)
 	reciever := make(chan string)
+	webhookReciever := make(chan string, 1)
 	return &App{
-		ClientId:     clientId,
-		ClientSecret: clientSecret,
-		RedirectURL:  redirectURL,
-		Scopes:       scopes,
+		ClientId:                    clientId,
+		ClientSecret:                clientSecret,
+		RedirectURL:                 redirectURL,
+		AuthorizationCallbackDomain: authorizationCallbackDomain,
+		WebhookServerURL:            webhookServerURL,
+		WebhookVerifyToken:          webhookVerifyToken,
+		WebhookReciever:             webhookReciever,
+		Scopes:                      scopes,
 
 		SwaggerConfig:         cfg,
 		OAuthConfig:           oauthCfg,
@@ -99,11 +146,13 @@ func NewApp(clientId string, clientSecret, redirectURL string, scopes []string) 
 		AuthorizationReciever: reciever,
 	}
 }
+
 // Return the approval url
 func (a *App) ApprovalUrl() string {
 	scopeStr := strings.Join(a.Scopes, ",")
 	return fmt.Sprintf(approvalUrlFormat, a.ClientId, responseType, a.RedirectURL, approvalPrompt, scopeStr)
 }
+
 // This is for the FIRST TIME getting the access token. It will set the token internally to the app.
 //
 // A user will grant permission to the app then will be redirected to the application's RedirectURL.
@@ -118,6 +167,7 @@ func (a *App) GetAccessTokenFromAuthorizationCode(ctx context.Context, code stri
 	a.SwaggerConfig.HTTPClient = httpClient
 	return token, nil
 }
+
 // Turn a json string token into an `oauth2.Token` struct and load it into the app
 func (a *App) LoadTokenString(tokenJsonString string) error {
 	var token oauth2.Token
@@ -130,28 +180,29 @@ func (a *App) LoadTokenString(tokenJsonString string) error {
 	a.SwaggerConfig.HTTPClient = httpClient
 	return nil
 }
+
 // Load an oauth2 token into the app
 func (a *App) LoadTokenDirect(token *oauth2.Token) {
 	httpClient := a.OAuthConfig.Client(context.TODO(), token)
 	a.Token = token
 	a.SwaggerConfig.HTTPClient = httpClient
 }
+
 // Load an oauth2 token into the app from a .json file
 func (a *App) LoadTokenFromFile(tokenFilePath string) error {
 	tokenData, err := os.ReadFile(tokenFilePath)
 	if err != nil {
 		return err
 	}
-
 	var token oauth2.Token
 	err = json.Unmarshal(tokenData, &token)
 	if err != nil {
 		return err
 	}
-
 	a.LoadTokenDirect(&token)
 	return nil
 }
+
 // Get the authorization code form the url that results from the redirect.
 // This is written to the AuthorizationReciever channel.
 //
@@ -166,6 +217,7 @@ func (a *App) stravaRedirectHandler(w http.ResponseWriter, r *http.Request) {
 		a.AuthorizationReciever <- "error:" + err
 	}
 }
+
 // Parse a url into its "address:port" and its "url/path"
 //
 // e.g. http://localhost:9999/strava/callback -> "localhost:9999", "strava/callback", err
@@ -174,8 +226,16 @@ func parseURL(inputURL string) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	return parsedURL.Host, parsedURL.Path[1:], nil // [1:] is used to remove the leading '/'
+	if len(parsedURL.Path) > 0 {
+		if string(parsedURL.Path[0]) == "/" {
+			return parsedURL.Host, parsedURL.Path[1:], nil // [1:] is used to remove the leading '/'
+		}
+		return parsedURL.Host, parsedURL.Path, nil
+	} else {
+		return parsedURL.Host, parsedURL.Path, nil
+	}
 }
+
 // Listen to the redirect route. Once the user is directed to it, we can extract the token from the url.
 //
 // Returns the Http server instance, so it can be shutdown when you like.
@@ -188,15 +248,15 @@ func (a *App) StartStravaHttpServer() (*http.Server, error) {
 	mux := http.NewServeMux()
 	srv := &http.Server{Addr: hostWithPort, Handler: mux}
 	mux.HandleFunc("/"+path, a.stravaRedirectHandler)
-
-	go func ()  {
+	go func() {
 		if err := srv.ListenAndServe(); err != http.ErrServerClosed {
-            // unexpected error. port in use?
-            //fmt.Println("ListenAndServe(): %v", err)
-        }
+			// unexpected error. port in use?
+			//fmt.Println("ListenAndServe(): %v", err)
+		}
 	}()
 	return srv, nil
 }
+
 // Run this function when you send the user to strava's authorization site.
 //
 // `timeoutDuration` is the time in seconds wait before returning nothing. Use -1 for no timeout duration.
@@ -216,7 +276,6 @@ func (a *App) StartStravaHttpServer() (*http.Server, error) {
 	}
 	code := <-s.App.AuthorizationReciever
 	fmt.Println("GOT CODE:" + code)
-
 	err := s.App.GetAccessTokenFromAuthorizationCode(context.TODO(), code)
 	if err != nil {
 		fmt.Println(err.Error())
@@ -231,10 +290,8 @@ func (a *App) AwaitInitialToken(timeoutDuration int) (*oauth2.Token, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	if timeoutDuration == -1 {
 		code := <-a.AuthorizationReciever
-
 		if strings.Contains(code, "error") {
 			server.Shutdown(ctx)
 			return nil, fmt.Errorf(code)
@@ -268,17 +325,20 @@ func (a *App) AwaitInitialToken(timeoutDuration int) (*oauth2.Token, error) {
 		}
 	}
 }
+
 // Open the Approval Url in the users browser
 func (a *App) OpenAuthorizationGrant() {
 	url := a.ApprovalUrl()
 	utils.OpenURL(url)
 }
+
 // Open the strava settings page
 //
 // This idea is to make it easy for the users to deauthenticate/revoke access to the app whenever they like.
 func (a *App) OpenStravaAppSettings() {
 	utils.OpenURL(stravaAppSettings)
 }
+
 // Create the OAuth2 token that is used for authentication in the app.
 //
 // The primary usecase for this is reading in a saved token from a database or file.
@@ -291,4 +351,179 @@ func (a *App) createToken(accessToken string, tokenType string, refreshToken str
 		RefreshToken: refreshToken,
 		Expiry:       expiry,
 	}
+}
+
+// this handler does a great deal of work
+//
+// When a get request is made, that is creating a subscription to the webhook:
+//
+//	must respond within 2 seconds to the get request from strava
+//	per https://developers.strava.com/docs/webhooks/ it must repond with http status 200 and the hub.challenge
+//	once this happens the original webhook POST request will receive a response
+//
+// When a post request is made, we are asking the webhook for new events
+func (a *App) webhookRedirectHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		challenge := r.URL.Query().Get("hub.challenge")
+		verificationToken := r.URL.Query().Get("hub.verify_token")
+		// if the verification token is not the same as when we created the subscription then we are not receiving the correct response
+		if verificationToken != a.WebhookVerifyToken {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		response, err := json.Marshal(map[string]string{"hub.challenge": challenge})
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(response)
+		a.WebhookReciever <- challenge // send the challenge to let the main request to read the post
+	case http.MethodPost:
+		defer r.Body.Close()
+		body, err := io.ReadAll(r.Body)
+		fmt.Println(string(body))
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		se := StravaEvent{}
+		err = json.Unmarshal(body, &se)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		if a.WebhookEventHandler != nil {
+			go func() {
+				a.WebhookEventHandler(se)
+			}()
+		} else {
+			fmt.Println("no event handler defined. doing nothing.")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+}
+
+// this is a one time run allowing you to subscribe to strava webhooks
+// returns:
+//   - the subscription id and the server that will be called to get events
+//   - the created server
+//   - a wait group. by calling wg.Wait() you keep the server running until it is explicitly stopped.
+//
+// note that the AuthorizationCallbackDomain MUST be open to the internet otherwise strava cannot send information to the server
+func (a *App) CreateSubscription() (int, *http.Server, *sync.WaitGroup, error) {
+	// the subscription process will return a challence to the callback url
+	// as such we need to be listening for that before we make the request
+	_, path, err := parseURL(a.AuthorizationCallbackDomain)
+	if err != nil {
+		return -1, nil, nil, err
+	}
+	hostWithPort, _, err := parseURL(a.WebhookServerURL)
+	if err != nil {
+		return -1, nil, nil, err
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/"+path, a.webhookRedirectHandler)
+	mux.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) { w.Write([]byte("alive")) })
+	srv := &http.Server{Addr: hostWithPort, Handler: mux}
+	wg := &sync.WaitGroup{}
+	go func() {
+		wg.Add(1)
+		if err := srv.ListenAndServe(); err != nil {
+			// unexpected error. port in use?
+			fmt.Printf("ListenAndServe(): %v\n", err)
+		}
+	}()
+	// make sure that the server is running
+	time.Sleep(1 * time.Second)
+	payload := map[string]string{
+		"client_id":     a.ClientId,
+		"client_secret": a.ClientSecret,
+		"callback_url":  a.AuthorizationCallbackDomain,
+		"verify_token":  a.WebhookVerifyToken,
+	}
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		wg.Done()
+		return -1, nil, nil, err
+	}
+	req, err := http.NewRequest(http.MethodPost, webhookSubscriptionsURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		wg.Done()
+		return -1, nil, nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		wg.Done()
+		return -1, nil, nil, err
+	}
+	defer resp.Body.Close()
+	// wait for the webhook verification challege to complete
+	// once this happens, strava has confirmed the webhook, so we are now expecting the response
+	_ = <-a.WebhookReciever
+	body, err := io.ReadAll(resp.Body)
+	fmt.Println(string(body))
+	if err != nil {
+		wg.Done()
+		return -1, nil, nil, err
+	}
+	type subscriptionResponse struct {
+		Id int `json:"id"`
+	}
+	sr := subscriptionResponse{}
+	err = json.Unmarshal(body, &sr)
+	if err != nil {
+		wg.Done()
+		return -1, nil, nil, err
+	}
+	return sr.Id, srv, wg, nil
+}
+
+// view the subscription associated with your client id/client secret
+// right now, just prints the response
+func (a *App) ViewSubscription() error {
+	url := fmt.Sprintf(webhookSubscriptionsURL+"?client_id=%s&client_secret=%s", a.ClientId, a.ClientSecret)
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	// TODO: struct-ify the response
+	fmt.Println(string(body))
+	return nil
+}
+
+// delete the subscription associated with your client id/client secret
+func (a *App) DeleteSubscription(subscriptionID string) error {
+	url := fmt.Sprintf(webhookSubscriptionsURL+"/%s?client_id=%s&client_secret=%s", subscriptionID, a.ClientId, a.ClientSecret)
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		return err
+	}
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	// TODO: struct-ify the response
+	fmt.Println(string(body))
+	return nil
 }

--- a/strava/app/webhooks/createSubscription.go
+++ b/strava/app/webhooks/createSubscription.go
@@ -1,0 +1,9 @@
+package webhooks
+
+const (
+   webhookSubscriptions = "https://www.strava.com/api/v3/push_subscriptions"
+)
+
+func CreateSubscription() {
+
+}

--- a/strava/cmd/config.tmpl.json
+++ b/strava/cmd/config.tmpl.json
@@ -2,6 +2,8 @@
     "client_id": "",
     "client_secret": "",
     "redirect_url": "",
-    "scopes": [],
-    "token_path": ""
+    "scopes": [""],
+    "token_path": "",
+    "authorization_callback_domain": "",
+    "webhook_server_url": ""
 }

--- a/strava/cmd/createApp.go
+++ b/strava/cmd/createApp.go
@@ -6,7 +6,7 @@ import (
 
 // Create the app based on the passed flag settings
 func createApp() (*app.App, error) {
-	stravaApp := app.NewApp(clientId, clientSecret, redirectURL, scopes)
+	stravaApp := app.NewApp(clientId, clientSecret, redirectURL, authorizationCallbackDomain, webhookServerURL, webhookVerifyToken, scopes)
 	// when we have a token, we want to load it in to the app
 	if tokenPath != "" {
 		err := stravaApp.LoadTokenFromFile(tokenPath)

--- a/strava/cmd/root.go
+++ b/strava/cmd/root.go
@@ -10,17 +10,19 @@ import (
 )
 
 const (
-	version string = "0.0.1"
+	version       string = "0.0.1"
 	defaultConfig string = ".cassidy-connector-strava.json"
 )
 
-
 type cfg struct {
-	ClientId string	`json:"client_id"`
-	ClientSecret string `json:"client_secret"`
-	RedirectURL string `json:"redirect_url"`
-	Scopes []string `json:"scopes"`
-	TokenPath string `json:"token_path"`
+	ClientId                    string   `json:"client_id"`
+	ClientSecret                string   `json:"client_secret"`
+	RedirectURL                 string   `json:"redirect_url"`
+	AuthorizationCallbackDomain string   `json:"authorization_callback_domain"`
+	WebhookServerURL            string   `json:"webhook_server_url"`
+	WebhookVerifyToken          string   `json:"webhook_verify_token"`
+	Scopes                      []string `json:"scopes"`
+	TokenPath                   string   `json:"token_path"`
 }
 
 // global app flag variables
@@ -30,21 +32,24 @@ var token string
 var clientId string
 var clientSecret string
 var redirectURL string
+var authorizationCallbackDomain string
+var webhookServerURL string
+var webhookVerifyToken string
 var scopes []string
 var outputPath string
 
 var RootCmd = &cobra.Command{
-	Use:   "cassidy-strava",
+	Use:     "cassidy-strava",
 	Version: version,
-	Short: "cassidy-strava is a cli tool to interact with the Strava API",
-	Long: `cassidy-strava is a cli tool to interact with the Strava API`,
+	Short:   "cassidy-strava is a cli tool to interact with the Strava API",
+	Long:    `cassidy-strava is a cli tool to interact with the Strava API`,
 	Run: func(cmd *cobra.Command, args []string) {
-	  // Do Stuff Here
+		// Do Stuff Here
 	},
 }
 
 var tokenCmdGroup = &cobra.Command{
-	Use: "api",
+	Use:   "api",
 	Short: "all subcommands here require a token for authentication",
 	Run: func(cmd *cobra.Command, args []string) {
 		// Nothing to see here
@@ -52,17 +57,13 @@ var tokenCmdGroup = &cobra.Command{
 }
 
 func initConfig() {
-
 	finalConfigPath := ""
-
 	if configPath != "" {
 		finalConfigPath = configPath
 	} else {
 		home, err := os.UserHomeDir()
 		cobra.CheckErr(err)
-
 		defaultConfigPath := home + "/" + defaultConfig
-
 		// Check if the file exists
 		if _, err := os.Stat(defaultConfigPath); err == nil {
 			// config exists
@@ -75,14 +76,11 @@ func initConfig() {
 			cobra.CheckErr(fmt.Errorf("uh oh, an unknown error occured"))
 		}
 	}
-
 	data, err := os.ReadFile(finalConfigPath)
 	cobra.CheckErr(err)
-
 	var config cfg
 	err = json.Unmarshal(data, &config)
 	cobra.CheckErr(err)
-
 	// set the relevant flags based on what the config provides
 	if config.ClientId != "" {
 		RootCmd.Flags().Set("client-id", config.ClientId)
@@ -92,6 +90,15 @@ func initConfig() {
 	}
 	if config.RedirectURL != "" {
 		RootCmd.Flags().Set("redirect-url", config.RedirectURL)
+	}
+	if config.AuthorizationCallbackDomain != "" {
+		RootCmd.Flags().Set("auth-callback-domain", config.AuthorizationCallbackDomain)
+	}
+	if config.WebhookServerURL != "" {
+		RootCmd.Flags().Set("webhook-server-url", config.WebhookServerURL)
+	}
+	if config.WebhookVerifyToken != "" {
+		RootCmd.Flags().Set("webhook-verify-token", config.WebhookVerifyToken)
 	}
 	if len(config.Scopes) > 0 {
 		scopeStr := strings.Join(config.Scopes, ",")
@@ -104,24 +111,23 @@ func initConfig() {
 
 func init() {
 	cobra.OnInitialize(initConfig)
-
 	RootCmd.PersistentFlags().StringVar(&configPath, "config", "", fmt.Sprintf("the config file of the application. see config.tmpl.json for format. a config is NOT required if you want to pass everything manually. (default is $HOME/%s)", defaultConfig))
 	RootCmd.PersistentFlags().StringVar(&clientId, "client-id", "", "the client id of your strava application")
 	RootCmd.PersistentFlags().StringVar(&clientSecret, "client-secret", "", "the client secret of your strava application")
 	RootCmd.PersistentFlags().StringVar(&redirectURL, "redirect-url", "http://localhost/exchange_token", "the redirect url of your strava application")
+	RootCmd.PersistentFlags().StringVar(&authorizationCallbackDomain, "auth-callback-domain", "", "the redirect url for the webhook. MUST be exposed to the internet and all traffic from here must be routed to webhook-server-url")
+	RootCmd.PersistentFlags().StringVar(&webhookServerURL, "webhook-server-url", "http://localhost:8086", "where the webhook server will run from")
+	RootCmd.PersistentFlags().StringVar(&webhookVerifyToken, "webhook-verify-token", "STRAVA", "the verification token for the webook just an arbritary token for verifying your app is receiving the correct webhook responses")
 	RootCmd.PersistentFlags().StringSliceVar(&scopes, "scopes", []string{"activity:read_all"}, "the scope requirement of your strava application")
-
 	RootCmd.PersistentFlags().StringVarP(&outputPath, "path", "f", "", "the path to save successful output to. (will not write errors at this time)")
-
 	RootCmd.MarkFlagsRequiredTogether("client-id", "client-secret")
-
 	tokenCmdGroup.PersistentFlags().StringVar(&tokenPath, "token-path", "", "the path to a .json file that contains an OAuth2 token. This json must conform to the `oauth2.Token` struct found here: https://pkg.go.dev/golang.org/x/oauth2#Token.")
 	tokenCmdGroup.PersistentFlags().StringVar(&token, "token", "", "a json token. you must include the entire token wrapped in ``. the json token conforms to `oauth2.Token` struct found here: https://pkg.go.dev/golang.org/x/oauth2#Token. (this is an ugly, but can be useful for testing purposes)")
 	tokenCmdGroup.MarkFlagsMutuallyExclusive("token-path", "token")
 	tokenCmdGroup.MarkFlagsOneRequired("token", "token-path")
-
 	RootCmd.AddCommand(tokenCmdGroup)
 }
+
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/strava/cmd/webhook.go
+++ b/strava/cmd/webhook.go
@@ -27,13 +27,36 @@ var createSubscription = &cobra.Command{
 			return
 		}
 		id, server, wg, err := stravaApp.CreateSubscription()
-		//server.Close()
 		if err != nil {
 			fmt.Println(err.Error())
 			return
 		}
 		fmt.Printf("server is running on %s\n", server.Addr)
 		fmt.Printf("subscription id: %d\n", id)
+		if keepAlive {
+			wg.Wait()
+		} else {
+			wg.Done()
+		}
+	},
+}
+
+var launchWebhookServer = &cobra.Command{
+	Use:   "launch-server",
+	Short: "launch the server. only do this if you have already created a webhook subscription.",
+	Args:  cobra.ExactArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		stravaApp, err := createApp()
+		if err != nil {
+			fmt.Println(err.Error())
+			return
+		}
+		server, wg, err := stravaApp.LaunchWebhookServer()
+		if err != nil {
+			fmt.Println(err.Error())
+			return
+		}
+		fmt.Printf("server is running on %s\n", server.Addr)
 		if keepAlive {
 			wg.Wait()
 		} else {
@@ -81,7 +104,9 @@ var deleteSubscription = &cobra.Command{
 
 func init() {
 	createSubscription.Flags().BoolVar(&keepAlive, "keep-alive", true, "keep the server alive after creation. the server is needed to get events from the webhook")
+	launchWebhookServer.Flags().BoolVar(&keepAlive, "keep-alive", true, "keep the server alive after creation. the server is needed to get events from the webhook")
 	webhookCmdGroup.AddCommand(createSubscription)
+	webhookCmdGroup.AddCommand(launchWebhookServer)
 	webhookCmdGroup.AddCommand(viewSubscription)
 	webhookCmdGroup.AddCommand(deleteSubscription)
 	RootCmd.AddCommand(webhookCmdGroup)

--- a/strava/cmd/webhook.go
+++ b/strava/cmd/webhook.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var keepAlive bool
+
+var webhookCmdGroup = &cobra.Command{
+	Use:   "webhook",
+	Short: "commands here are used for interacting with the strava webhooks",
+	Run: func(cmd *cobra.Command, args []string) {
+		// Nothing to see here
+	},
+}
+
+var createSubscription = &cobra.Command{
+	Use:   "create",
+	Short: "create a subscription for your app. this is a one-time run. note that this will spawn a server at the callback url that recieves events",
+	Args:  cobra.ExactArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		stravaApp, err := createApp()
+		if err != nil {
+			fmt.Println(err.Error())
+			return
+		}
+		id, server, wg, err := stravaApp.CreateSubscription()
+		//server.Close()
+		if err != nil {
+			fmt.Println(err.Error())
+			return
+		}
+		fmt.Printf("server is running on %s\n", server.Addr)
+		fmt.Printf("subscription id: %d\n", id)
+		if keepAlive {
+			wg.Wait()
+		} else {
+			wg.Done()
+		}
+	},
+}
+
+var viewSubscription = &cobra.Command{
+	Use:   "view",
+	Short: "view subscription for your app",
+	Args:  cobra.ExactArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		stravaApp, err := createApp()
+		if err != nil {
+			fmt.Println(err.Error())
+			return
+		}
+		err = stravaApp.ViewSubscription()
+		if err != nil {
+			fmt.Println(err.Error())
+			return
+		}
+	},
+}
+
+var deleteSubscription = &cobra.Command{
+	Use:   "delete [subscription id]",
+	Short: "delete subscription for your app",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		subscriptionID := args[0]
+		stravaApp, err := createApp()
+		if err != nil {
+			fmt.Println(err.Error())
+			return
+		}
+		err = stravaApp.DeleteSubscription(subscriptionID)
+		if err != nil {
+			fmt.Println(err.Error())
+			return
+		}
+	},
+}
+
+func init() {
+	createSubscription.Flags().BoolVar(&keepAlive, "keep-alive", true, "keep the server alive after creation. the server is needed to get events from the webhook")
+	webhookCmdGroup.AddCommand(createSubscription)
+	webhookCmdGroup.AddCommand(viewSubscription)
+	webhookCmdGroup.AddCommand(deleteSubscription)
+	RootCmd.AddCommand(webhookCmdGroup)
+}


### PR DESCRIPTION
This PR implements Strava webhooks meaning users will no longer need to poll for changes.

This is done by allowing the user to define a function that processes webhook events.

Moreover, the ability to create, view and delete subscriptions is added. 

Creating a subscription launches a server that will listen for events. The server can also be relaunched at any time with the `LaunchWebhookServer` function.