### PR TITLE
depreciate token server

### DIFF
--- a/strava/app/app.go
+++ b/strava/app/app.go
@@ -344,7 +344,7 @@ func (a *App) CreateSubscription() (int, *http.Server, *sync.WaitGroup, error) {
 	payload := map[string]string{
 		"client_id":     a.ClientId,
 		"client_secret": a.ClientSecret,
-		"callback_url":  a.AuthorizationCallbackDomain,
+		"callback_url":  fmt.Sprintf("%s%s", a.AuthorizationCallbackDomain, a.WebhookPath),
 		"verify_token":  a.WebhookVerifyToken,
 	}
 	jsonData, err := json.Marshal(payload)
@@ -407,7 +407,7 @@ func (a *App) LaunchWebhookServer() (*http.Server, *sync.WaitGroup, error) {
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc(a.WebhookPath, a.webhookRedirectHandler)
-	mux.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) { w.Write([]byte("alive")) })
+	mux.HandleFunc(fmt.Sprintf("%s/status", a.WebhookPath), func(w http.ResponseWriter, r *http.Request) { w.Write([]byte("alive")) })
 	srv := &http.Server{Addr: hostWithPort, Handler: mux}
 	wg := &sync.WaitGroup{}
 	wg.Add(1)

--- a/strava/app/webhooks/createSubscription.go
+++ b/strava/app/webhooks/createSubscription.go
@@ -1,9 +1,0 @@
-package webhooks
-
-const (
-   webhookSubscriptions = "https://www.strava.com/api/v3/push_subscriptions"
-)
-
-func CreateSubscription() {
-
-}

--- a/strava/cmd/config.tmpl.json
+++ b/strava/cmd/config.tmpl.json
@@ -1,9 +1,10 @@
 {
     "client_id": "",
     "client_secret": "",
-    "redirect_url": "",
+    "authorization_callback_domain": "",
+    "callback_path": "",
+    "webhook_path": ""
     "scopes": [""],
     "token_path": "",
-    "authorization_callback_domain": "",
     "webhook_server_url": ""
 }

--- a/strava/cmd/createApp.go
+++ b/strava/cmd/createApp.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"log/slog"
+	"os"
 
 	"github.com/jcocozza/cassidy-connector/strava/app"
 	"golang.org/x/oauth2"
@@ -22,7 +23,7 @@ func createApp() (*app.App, *oauth2.Token, error) {
 		nil,
 		scopes,
 		//nil,// no logger for the cli
-		slog.Default(),
+		slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug})),
 	)
 	// when we have a token, we want to load it in to the app
 	if tokenPath != "" {

--- a/strava/cmd/createApp.go
+++ b/strava/cmd/createApp.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"log/slog"
+
 	"github.com/jcocozza/cassidy-connector/strava/app"
 	"golang.org/x/oauth2"
 )
@@ -12,13 +14,15 @@ func createApp() (*app.App, *oauth2.Token, error) {
 	stravaApp := app.NewApp(
 		clientId,
 		clientSecret,
-		redirectURL,
 		authorizationCallbackDomain,
+		callbackPath,
+		webhookPath,
 		webhookServerURL,
 		webhookVerifyToken,
 		nil,
 		scopes,
-		nil,// no logger for the cli
+		//nil,// no logger for the cli
+		slog.Default(),
 	)
 	// when we have a token, we want to load it in to the app
 	if tokenPath != "" {

--- a/strava/cmd/root.go
+++ b/strava/cmd/root.go
@@ -17,8 +17,9 @@ const (
 type cfg struct {
 	ClientId                    string   `json:"client_id"`
 	ClientSecret                string   `json:"client_secret"`
-	RedirectURL                 string   `json:"redirect_url"`
 	AuthorizationCallbackDomain string   `json:"authorization_callback_domain"`
+	CallbackPath				string 	 `json:"callback_path"`
+	WebhookPath                 string 	 `json:"webhook_path"`
 	WebhookServerURL            string   `json:"webhook_server_url"`
 	WebhookVerifyToken          string   `json:"webhook_verify_token"`
 	Scopes                      []string `json:"scopes"`
@@ -33,6 +34,8 @@ var clientId string
 var clientSecret string
 var redirectURL string
 var authorizationCallbackDomain string
+var callbackPath string
+var webhookPath string
 var webhookServerURL string
 var webhookVerifyToken string
 var scopes []string
@@ -88,11 +91,14 @@ func initConfig() {
 	if config.ClientSecret != "" {
 		RootCmd.Flags().Set("client-secret", config.ClientSecret)
 	}
-	if config.RedirectURL != "" {
-		RootCmd.Flags().Set("redirect-url", config.RedirectURL)
-	}
 	if config.AuthorizationCallbackDomain != "" {
 		RootCmd.Flags().Set("auth-callback-domain", config.AuthorizationCallbackDomain)
+	}
+	if config.CallbackPath != "" {
+		RootCmd.Flags().Set("callback-path", config.CallbackPath)
+	}
+	if config.WebhookPath != "" {
+		RootCmd.Flags().Set("webhook-path", config.WebhookPath)
 	}
 	if config.WebhookServerURL != "" {
 		RootCmd.Flags().Set("webhook-server-url", config.WebhookServerURL)
@@ -114,8 +120,9 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&configPath, "config", "", fmt.Sprintf("the config file of the application. see config.tmpl.json for format. a config is NOT required if you want to pass everything manually. (default is $HOME/%s)", defaultConfig))
 	RootCmd.PersistentFlags().StringVar(&clientId, "client-id", "", "the client id of your strava application")
 	RootCmd.PersistentFlags().StringVar(&clientSecret, "client-secret", "", "the client secret of your strava application")
-	RootCmd.PersistentFlags().StringVar(&redirectURL, "redirect-url", "http://localhost/exchange_token", "the redirect url of your strava application")
 	RootCmd.PersistentFlags().StringVar(&authorizationCallbackDomain, "auth-callback-domain", "", "the redirect url for the webhook. MUST be exposed to the internet and all traffic from here must be routed to webhook-server-url")
+	RootCmd.PersistentFlags().StringVar(&callbackPath, "callback-path", "/strava/callback", "the path off the authorization callback domain for the auth callback")
+	RootCmd.PersistentFlags().StringVar(&webhookPath, "webhook-path", "/webhook", "the path off the authorization callback domain for the webhook")
 	RootCmd.PersistentFlags().StringVar(&webhookServerURL, "webhook-server-url", "http://localhost:8086", "where the webhook server will run from")
 	RootCmd.PersistentFlags().StringVar(&webhookVerifyToken, "webhook-verify-token", "STRAVA", "the verification token for the webook just an arbritary token for verifying your app is receiving the correct webhook responses")
 	RootCmd.PersistentFlags().StringSliceVar(&scopes, "scopes", []string{"activity:read_all"}, "the scope requirement of your strava application")


### PR DESCRIPTION
I've determined that receiving the token is out of scope for this tool.

Instead, users need to receive on their own end point.

From there, you can exchange the code for a token.